### PR TITLE
psx_shader_godot_shadows_and_extras

### DIFF
--- a/psx_shader_godot_shadows_and_extras
+++ b/psx_shader_godot_shadows_and_extras
@@ -1,0 +1,33 @@
+shader_type spatial; 
+render_mode skip_vertex_transform, diffuse_burley; 
+
+//Albedo texture 
+uniform sampler2D albedoTex : hint_albedo; //Geometric resolution for vert sna[ 
+uniform float snapRes = 8.0; 
+uniform float roughness = 1.0;
+uniform float specular = 0.1;
+uniform vec2 uv_scale = vec2(1.0, 1.0);
+uniform vec2 uv_offset = vec2(.0, .0);
+
+uniform float light_intensity = 0.3;
+
+//vec4 for UV recalculation 
+varying vec4 vertCoord; 
+void vertex() { 
+	UV = UV * uv_scale + uv_offset;
+	VERTEX = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz; 
+	VERTEX.xyz = floor(VERTEX.xyz * snapRes) / snapRes; 
+	vertCoord = vec4(UV * VERTEX.x, VERTEX.z, 0); 
+} 
+void fragment() { 
+	
+	ROUGHNESS =roughness;
+	SPECULAR = specular;
+	ALBEDO = texture(albedoTex, UV).rgb; }
+//QUICK FIX TO LIGHTING
+void light()
+{
+
+	DIFFUSE_LIGHT = ALBEDO*LIGHT_COLOR*ATTENUATION*light_intensity;
+
+}


### PR DESCRIPTION
Not the best fix for the shadows issue but it works. This shader will show lighting stronger though, so I added an extra param  called light_intensity. If you need to dim down the intensity of the light recieved just use a value below 1.0, for instance: 0.5 will half the intensity.

Also added some extra params for roughness and specular, just a quality of life thing if you need to make a metalic material or something more reflective.

The issue with lighting was pretty much that this shader is not rendering correctly the vertex lighting, so the easy fix was to just add the function light() and manually code the lighting. You can play around with DIFFUSE_LIGHT and get cool effects as well. 

Cheers.